### PR TITLE
feat: move Acme Group logo to Manufacturing Excellence header

### DIFF
--- a/src/pages/Manufacturing.tsx
+++ b/src/pages/Manufacturing.tsx
@@ -72,9 +72,18 @@ const Manufacturing = () => {
         <div className="absolute inset-0 bg-gradient-to-r from-slate-900/85 via-slate-800/75 to-slate-900/85"></div>
         
         <div className="container mx-auto text-center relative z-10">
-          <h1 className="text-5xl md:text-6xl font-bold mb-6">
-            Manufacturing <span className="text-white/90">Excellence</span>
-          </h1>
+          <div className="flex items-center justify-center mb-8">
+            <div className="bg-white/10 backdrop-blur-sm p-4 rounded-lg mr-6">
+              <img 
+                src="https://i.ibb.co/5g3yJ9vz/acme-group-logo.webp" 
+                alt="Acme Group Logo" 
+                className="h-16 md:h-20 object-contain"
+              />
+            </div>
+            <h1 className="text-5xl md:text-6xl font-bold">
+              Manufacturing <span className="text-white/90">Excellence</span>
+            </h1>
+          </div>
           <p className="text-xl md:text-2xl text-white/90 max-w-4xl mx-auto">
             40 years of pharmaceutical manufacturing expertise with cutting-edge facilities
           </p>
@@ -91,18 +100,9 @@ const Manufacturing = () => {
         
         <div className="container mx-auto relative z-10">
           <div className="text-center mb-12">
-            <div className="flex items-center justify-center mb-6">
-              <div className="bg-primary p-3 rounded-lg mr-4">
-                <img 
-                  src="https://i.ibb.co/5g3yJ9vz/acme-group-logo.webp" 
-                  alt="Acme Group Logo" 
-                  className="h-16 md:h-20 object-contain"
-                />
-              </div>
-              <h2 className="text-4xl md:text-5xl font-bold text-foreground">
-                Manufacturing <span className="gradient-text">Prowess</span>
-              </h2>
-            </div>
+            <h2 className="text-4xl md:text-5xl font-bold text-foreground mb-6">
+              Manufacturing <span className="gradient-text">Prowess</span>
+            </h2>
           </div>
 
           <div className="grid lg:grid-cols-3 gap-8">


### PR DESCRIPTION
## Summary
- Moved Acme Group logo from Manufacturing Prowess section to Manufacturing Excellence header
- Logo now appears in front of background image with semi-transparent backdrop
- Cleaned up Manufacturing Prowess section styling

##  Changes
- Updated Manufacturing Excellence header to include logo with backdrop blur effect
- Removed logo from Manufacturing Prowess section
- Maintained all existing text and functionality

Closes #12

Generated with [Claude Code](https://claude.ai/code)