### PR TITLE
fix: make stats section responsive for mobile and iPad

### DIFF
--- a/src/components/AboutBrief.tsx
+++ b/src/components/AboutBrief.tsx
@@ -51,21 +51,21 @@ const AboutBrief = () => {
 
           {/* Right Stats */}
           <div>
-            <div className="grid grid-cols-2 gap-8">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6 md:gap-8">
               {stats.map((stat, index) => (
                 <div 
                   key={stat.label}
-                  className="text-center p-6 card-pharmaceutical group"
+                  className="text-center p-4 sm:p-6 card-pharmaceutical group"
                   style={{ 
                     opacity: 1,
                     transform: 'translateY(0)',
                     animation: `scale-in 0.6s ease-out ${index * 0.1}s both`
                   }}
                 >
-                  <div className="text-4xl md:text-5xl font-bold text-primary mb-2 group-hover:scale-110 transition-transform duration-300">
+                  <div className="text-3xl sm:text-4xl md:text-5xl font-bold text-primary mb-2 group-hover:scale-110 transition-transform duration-300">
                     {stat.number}{stat.suffix}
                   </div>
-                  <div className="text-muted-foreground font-medium">{stat.label}</div>
+                  <div className="text-sm sm:text-base text-muted-foreground font-medium">{stat.label}</div>
                 </div>
               ))}
             </div>

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -85,21 +85,21 @@ const About = () => {
       {/* Company Stats Section */}
       <section className="section-padding bg-background -mt-16 relative z-20">
         <div className="container mx-auto">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 sm:gap-6 max-w-4xl mx-auto">
             {companyStats.map((stat, index) => (
               <div 
                 key={stat.label}
-                className="card-pharmaceutical p-6 text-center group"
+                className="card-pharmaceutical p-4 sm:p-6 text-center group"
                 style={{ 
                   animationDelay: `${index * 0.1}s`,
                   animation: 'fade-in-up 0.8s ease-out both'
                 }}
               >
-                <div className="inline-flex p-3 bg-primary-light rounded-full mb-4 group-hover:bg-primary transition-all duration-300">
-                  <stat.icon className="h-6 w-6 text-primary group-hover:text-primary-foreground" />
+                <div className="inline-flex p-2 sm:p-3 bg-primary-light rounded-full mb-3 sm:mb-4 group-hover:bg-primary transition-all duration-300">
+                  <stat.icon className="h-5 w-5 sm:h-6 sm:w-6 text-primary group-hover:text-primary-foreground" />
                 </div>
-                <div className="counter-number text-3xl font-bold text-primary mb-2">{stat.number}</div>
-                <p className="text-muted-foreground font-medium text-sm">{stat.label}</p>
+                <div className="counter-number text-2xl sm:text-3xl font-bold text-primary mb-2">{stat.number}</div>
+                <p className="text-muted-foreground font-medium text-xs sm:text-sm">{stat.label}</p>
               </div>
             ))}
           </div>


### PR DESCRIPTION
This PR makes the stats section responsive on both the homepage and about us page.

## Changes
- Homepage: Changed from fixed 2-column grid to responsive layout
- About page: Enhanced grid responsiveness with proper mobile breakpoints
- Adjusted padding, text sizes, and spacing for optimal mobile experience

## Responsive Behavior
- Mobile (<640px): Single column layout
- Tablet/iPad (640px+): Two column layout
- Desktop (768px+): Four columns on About page

Closes #14

Generated with [Claude Code](https://claude.ai/code)