### PR TITLE
fix: improve mobile navbar and manufacturing banner responsiveness

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -262,12 +262,17 @@ const Navigation = () => {
                     <span className="text-lg font-medium text-foreground">Products</span>
                     <div className="mt-2 pl-4 space-y-2">
                       {productCategories.map((category) => (
-                        <div key={category.id} className="flex items-center space-x-3 py-1">
+                        <Link
+                          key={category.id}
+                          to={`/products/${category.id}`}
+                          onClick={() => setIsMobileMenuOpen(false)}
+                          className="flex items-center space-x-3 py-1 hover:text-primary transition-colors duration-200"
+                        >
                           <div className={`p-1 ${category.color} rounded`}>
                             <category.icon className="h-3 w-3 text-white" />
                           </div>
-                          <span className="text-sm text-muted-foreground">{category.name}</span>
-                        </div>
+                          <span className="text-sm text-muted-foreground hover:text-primary transition-colors duration-200">{category.name}</span>
+                        </Link>
                       ))}
                     </div>
                   </div>

--- a/src/pages/Manufacturing.tsx
+++ b/src/pages/Manufacturing.tsx
@@ -72,19 +72,19 @@ const Manufacturing = () => {
         <div className="absolute inset-0 bg-gradient-to-r from-slate-900/85 via-slate-800/75 to-slate-900/85"></div>
         
         <div className="container mx-auto text-center relative z-10">
-          <div className="flex items-center justify-center mb-8">
-            <div className="bg-white/10 backdrop-blur-sm p-4 rounded-lg mr-6">
+          <div className="flex flex-col md:flex-row items-center justify-center mb-8">
+            <div className="bg-white/10 backdrop-blur-sm p-3 md:p-4 rounded-lg mb-4 md:mb-0 md:mr-6">
               <img 
                 src="https://i.ibb.co/5g3yJ9vz/acme-group-logo.webp" 
                 alt="Acme Group Logo" 
-                className="h-16 md:h-20 object-contain"
+                className="h-12 sm:h-14 md:h-16 lg:h-20 object-contain"
               />
             </div>
-            <h1 className="text-5xl md:text-6xl font-bold">
-              Manufacturing <span className="text-white/90">Excellence</span>
+            <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold leading-tight">
+              Manufacturing <span className="text-white/90 block sm:inline">Excellence</span>
             </h1>
           </div>
-          <p className="text-xl md:text-2xl text-white/90 max-w-4xl mx-auto">
+          <p className="text-lg sm:text-xl md:text-2xl text-white/90 max-w-4xl mx-auto px-4">
             40 years of pharmaceutical manufacturing expertise with cutting-edge facilities
           </p>
         </div>


### PR DESCRIPTION
This PR fixes two mobile UI issues:

## Changes

**1. Mobile Navigation Products Button**
- Fixed product category links not being clickable in mobile menu
- Converted static spans to clickable Link components
- Added proper navigation to product pages and menu closing
- Improved hover effects and transitions

**2. Manufacturing Banner Responsiveness**
- Enhanced mobile and iPad layout of hero section
- Changed from horizontal-only to responsive flex layout
- Improved logo and title sizing across breakpoints
- Added smart text breaking for better readability
- Enhanced spacing and padding for mobile devices

Fixes #16

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product categories in the mobile menu are now clickable, allowing direct navigation to category pages and automatically closing the menu upon selection.

* **Style**
  * Improved responsiveness and layout of the hero section on the Manufacturing page, including better stacking, spacing, and font adjustments for various screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->